### PR TITLE
Kabum.com.br and others

### DIFF
--- a/SpywareFilter/sections/tracking_servers.txt
+++ b/SpywareFilter/sections/tracking_servers.txt
@@ -3172,6 +3172,7 @@
 ||controlswim.com^$third-party
 ||scatteredheat.com^$third-party
 ||gleamingtrade.com^$third-party
+||goadopt.io^$third-party
 ||movemeal.com^$third-party
 ||lorenzourban.com^$third-party
 ||youngmarble.com^$third-party


### PR DESCRIPTION
<details><summary>Screenshot:</summary>

![image](https://user-images.githubusercontent.com/47755037/105771340-52739780-5f58-11eb-9df6-9aa98b1ca8a0.png)
</details>

This is a recent tracker and is growing in Brazil since the approval of LGPD (Brazilian version of GDPR)

You can find it on several local sites. Some examples in addition to the already mentioned:

<details><summary>meioemensagem.com.br</summary>

![image](https://user-images.githubusercontent.com/47755037/105772068-8bf8d280-5f59-11eb-9f5e-4b77bc77fb14.png)
</details>

<details><summary>piracanjuba.com.br</summary>

![image](https://user-images.githubusercontent.com/47755037/105772149-a763dd80-5f59-11eb-906d-e32b6eae25c8.png)
</details>
